### PR TITLE
Fix docs typo: step() -> act()

### DIFF
--- a/habitat/core/agent.py
+++ b/habitat/core/agent.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 r"""Base implementation of agent inside habitat. To build agents inside habitat 
-the user should subclass ``habitat.Agent`` and implement the ``step()``
+the user should subclass ``habitat.Agent`` and implement the ``act()``
 and ``reset()`` methods.
 """
 


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
Current docs for `habitat.Agent` point to implement nonexisting method `step()`, instead of `act()`.
## How Has This Been Tested
No testing
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change / refactoring / dependency upgrade

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
